### PR TITLE
Update fileconf.c

### DIFF
--- a/fileconf.c
+++ b/fileconf.c
@@ -1279,7 +1279,7 @@ check_username(char *ptr, cf_t * cf, cl_t * cl)
     strncpy(username, ptr, indx);
     username[indx] = '\0';
 
-    if ((userpwent = getpwnam(username)) != NULL) {
+    if (username[0]!='\0' && (userpwent=getpwnam(username))!=NULL) {
         /* found the user */
         ptr = ptr + indx;       /* move ptr to the next word */
         Skip_blanks(ptr);


### PR DESCRIPTION
I have encountered a problem for a long time with pam and nslcd, which produces an unnecessary warning when calling "fcrontab <crontabfile>" as user root.
It produces an output similar in /var/log/warn
  "nslcd[673]: [...] <passwd=""> request denied by validnames option"
Thats because there is no check that the variable username is not empty and the nslcd-daemon acknowledges this with the warning above.
